### PR TITLE
Implement ICriticalNotifyCompletion

### DIFF
--- a/src/TaskTupleAwaiter/TaskTupleExtensions.cs
+++ b/src/TaskTupleAwaiter/TaskTupleExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Security;
 using System.Threading.Tasks;
 // ReSharper disable ImpureMethodCallOnReadonlyValueField
 
@@ -23,7 +24,7 @@ namespace TaskTupleAwaiter
 			GetAwaiter<T1, T2>(this (Task<T1>, Task<T2>) tasks) =>
 			new TupleTaskAwaiter<T1, T2>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>) _tasks;
 			private readonly TaskAwaiter _whenAllAwaiter;
@@ -38,6 +39,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2) GetResult()
 			{
@@ -64,7 +69,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>) _tasks;
 
@@ -83,6 +88,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -98,7 +107,7 @@ namespace TaskTupleAwaiter
 			this (Task<T1>, Task<T2>, Task<T3>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>) _tasks;
 			private readonly TaskAwaiter _whenAllAwaiter;
@@ -111,7 +120,13 @@ namespace TaskTupleAwaiter
 			}
 
 			public bool IsCompleted => _whenAllAwaiter.IsCompleted;
-			public void OnCompleted(Action continuation) => _whenAllAwaiter.OnCompleted(continuation);
+
+			public void OnCompleted(Action continuation) =>
+				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3) GetResult()
 			{
@@ -141,7 +156,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>) _tasks;
 				private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter;
@@ -159,6 +174,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -173,7 +192,7 @@ namespace TaskTupleAwaiter
 			this (Task<T1>, Task<T2>, Task<T3>, Task<T4>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>) _tasks;
 			private readonly TaskAwaiter _whenAllAwaiter;
@@ -189,6 +208,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4) GetResult()
 			{
@@ -220,7 +243,7 @@ namespace TaskTupleAwaiter
 
 			public Awaiter GetAwaiter() => new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>) _tasks;
 				private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter;
@@ -238,6 +261,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -254,7 +281,7 @@ namespace TaskTupleAwaiter
 				this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4, T5>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) _tasks;
 			private readonly TaskAwaiter _whenAllAwaiter;
@@ -271,6 +298,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5) GetResult()
 			{
@@ -303,7 +334,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>) _tasks;
 
@@ -323,6 +354,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4, T5) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -339,7 +374,7 @@ namespace TaskTupleAwaiter
 				this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4, T5, T6>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>)
 				_tasks;
@@ -357,6 +392,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5, T6) GetResult()
 			{
@@ -390,7 +429,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>) _tasks;
 				private readonly ConfiguredTaskAwaitable.ConfiguredTaskAwaiter _whenAllAwaiter;
@@ -409,6 +448,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4, T5, T6) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -425,7 +468,7 @@ namespace TaskTupleAwaiter
 				this (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>, Task<T7>)
 					tasks) => new TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>,
 				Task<T7>) _tasks;
@@ -445,6 +488,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5, T6, T7) GetResult()
 			{
@@ -479,7 +526,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>
 					, Task<T7>) _tasks;
@@ -501,6 +548,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4, T5, T6, T7) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -519,7 +570,7 @@ namespace TaskTupleAwaiter
 					Task<T8>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>,
 				Task<T7>, Task<T8>) _tasks;
@@ -539,6 +590,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5, T6, T7, T8) GetResult()
 			{
@@ -573,7 +628,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>
 					, Task<T7>, Task<T8>) _tasks;
@@ -595,6 +650,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4, T5, T6, T7, T8) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -613,7 +672,7 @@ namespace TaskTupleAwaiter
 					Task<T8>, Task<T9>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>,
 				Task<T7>, Task<T8>, Task<T9>) _tasks;
@@ -633,6 +692,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5, T6, T7, T8, T9) GetResult()
 			{
@@ -668,7 +731,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>
 					, Task<T7>, Task<T8>, Task<T9>) _tasks;
@@ -690,6 +753,10 @@ namespace TaskTupleAwaiter
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
 
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
+
 				public (T1, T2, T3, T4, T5, T6, T7, T8, T9) GetResult()
 				{
 					_whenAllAwaiter.GetResult();
@@ -708,7 +775,7 @@ namespace TaskTupleAwaiter
 					Task<T8>, Task<T9>, Task<T10>) tasks) =>
 			new TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(tasks);
 
-		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : INotifyCompletion
+		public struct TupleTaskAwaiter<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : ICriticalNotifyCompletion
 		{
 			private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>,
 				Task<T7>, Task<T8>, Task<T9>, Task<T10>) _tasks;
@@ -728,6 +795,10 @@ namespace TaskTupleAwaiter
 
 			public void OnCompleted(Action continuation) =>
 				_whenAllAwaiter.OnCompleted(continuation);
+
+			[SecurityCritical]
+			public void UnsafeOnCompleted(Action continuation) =>
+				_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 			public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) GetResult()
 			{
@@ -764,7 +835,7 @@ namespace TaskTupleAwaiter
 			public Awaiter GetAwaiter() =>
 				new Awaiter(_tasks, _continueOnCapturedContext);
 
-			public struct Awaiter : INotifyCompletion
+			public struct Awaiter : ICriticalNotifyCompletion
 			{
 				private readonly (Task<T1>, Task<T2>, Task<T3>, Task<T4>, Task<T5>, Task<T6>
 					, Task<T7>, Task<T8>, Task<T9>, Task<T10>) _tasks;
@@ -785,6 +856,10 @@ namespace TaskTupleAwaiter
 
 				public void OnCompleted(Action continuation) =>
 					_whenAllAwaiter.OnCompleted(continuation);
+
+				[SecurityCritical]
+				public void UnsafeOnCompleted(Action continuation) =>
+					_whenAllAwaiter.UnsafeOnCompleted(continuation);
 
 				public (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) GetResult()
 				{


### PR DESCRIPTION
tl;dr This is an optimization encouraged for all custom awaiters. Since it makes sense on `TaskAwaiter`, it makes sense on our syntactic wrapper around `TaskAwaiter`.

Background from Stephen Toub's excellent https://blogs.msdn.microsoft.com/pfxteam/2012/02/29/whats-new-for-parallelism-in-net-4-5-beta:

> The second new interface is ICriticalNotifyCompletion, which inherits from INotifyCompletion.  In addition to the OnCompleted method, it also exposes an UnsafeOnCompleted method:
> 
> ```cs
> public interface ICriticalNotifyCompletion : INotifyCompletion
> {
>     [SecurityCritical]
>     void UnsafeOnCompleted(Action continuation);
> }
> ```
> 
> For those of you familiar with ThreadPool.UnsafeQueueUserWorkItem, you might be able to guess what is UnsafeOnCompleted.  In short, it’s exactly the same as INotifyCompletion.OnCompleted, except that it doesn’t need to flow ExecutionContext.
> 
> If an awaiter implements just INotifyCompletion, obviously the compiler will target its OnCompleted when implementing the async method’s state machine.  If, however, an awaiter also implements ICriticalNotifyCompletion, the compiler will target its UnsafeOnCompleted method.
> 
> For those of you familiar with ExecutionContext, at this point you’re likely asking yourself, “What?  How is that safe?  Doesn’t ExecutionContext need to flow across await points?”  Yes, it does.  However, what we discovered with the Async CTP and with the .NET 4.5 Developer Preview is that many folks didn’t realize that their awaiters needed to flow ExecutionContext in order to ensure context flowed across await points (even for those that did, this was a bit of a headache to implement).  So, for .NET 4.5 Beta, we’ve modified the async method builders in the Framework (e.g. AsyncTaskMethodBuilder); these are the types targeted by the compilers when building the state machines for async methods. The builders now themselves flow ExecutionContext across await points, taking that responsibility away from the awaiters.  That’s why it’s ok for the compilers to target UnsafeOnCompleted, because the builders will handle ExecutionContext flow.  That’s also why we needed the interfaces for awaiters, such that the builders could be passed references to awaiters and be able to invoke their {Unsafe}OnCompleted methods polymorphically.
> Your next question then is likely, “Great, the builder is handling ExecutionContext flow… so why do we need two *OnCompleted methods?  Why can’t we just have an OnCompleted that doesn’t flow context?”  I’m glad you asked.  If you’re building an assembly with AllowPartiallyTrustedCallersAttribute (APTCA) applied to it, you need to ensure that any publicly exposed APIs from your assembly correctly flow ExecutionContext across async points… failure to do so can be a big security hole.  As awaiter types will often be implemented in APTCA assemblies, and since OnCompleted could be called directly by a user (even though it’s really meant to be used by the compiler), OnCompleted needs to flow ExecutionContext.  But if OnCompleted flows ExecutionContext, and if the builder flows ExecutionContext, now we’ll be flowing ExecutionContext twice.  While that’s not a problem functionally, it is an unnecessary and (potentially) non-trivial performance overhead.  So, we also have UnsafeOnCompleted, which doesn’t need to flow ExecutionContext, but which is also marked as SecurityCritical, such that partially trusted code can’t call it.
> If you’re implementing your own awaiter, whenever possible implement both INotifyCompletion and ICriticalNotifyCompletion, flowing ExecutionContext in the former and not flowing it in the latter.  The only good reason not to implement both is if you’re implementing an awaiter in a situation where you can’t flow ExecutionContext, e.g. where your awaiter is partially trusted or where you otherwise don’t have the ability to use ExecutionContext, or where the APIs on which your awaiter relies doesn’t give you any option as to whether to flow context or not… in such cases, you can just implement INotifyCompletion.

See also: https://docs.microsoft.com/dotnet/csharp/language-reference/language-specification/expressions#runtime-evaluation-of-await-expressions