### PR TITLE
Fix TupleConfiguredTaskAwaitable to wait for all tasks

### DIFF
--- a/src/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/src/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -129,6 +130,215 @@ namespace TaskTupleAwaiter.Tests
 			Assert.IsType<Guid>(j);
 		}
 
+		public static IEnumerable<object[]> ContinueOnCapturedContextOptions()
+		{
+			yield return new object[] { true };
+			yield return new object[] { false };
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitThreeTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitFourTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitFiveTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitSixTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var task5 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, task5, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(task5.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e, f) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitSevenTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var task5 = GetStringAsync();
+			var task6 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, task5, task6, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(task5.IsCompleted);
+				Assert.True(task6.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e, f, g) = await waitAllTask;
+		}
+
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitEightTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var task5 = GetStringAsync();
+			var task6 = GetStringAsync();
+			var task7 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, task5, task6, task7, slowTask).ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(task5.IsCompleted);
+				Assert.True(task6.IsCompleted);
+				Assert.True(task7.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e, f, g, h) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitNineTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var task5 = GetStringAsync();
+			var task6 = GetStringAsync();
+			var task7 = GetStringAsync();
+			var task8 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, task5, task6, task7, task8, slowTask)
+				.ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(task5.IsCompleted);
+				Assert.True(task6.IsCompleted);
+				Assert.True(task7.IsCompleted);
+				Assert.True(task8.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e, f, g, h, i) = await waitAllTask;
+		}
+
+		[Theory]
+		[MemberData(nameof(ContinueOnCapturedContextOptions))]
+		public async Task AwaitTenTasksWaitsForAllOfThemWhenConfigured(bool continueOnCapturedContext)
+		{
+			var task1 = GetStringAsync();
+			var task2 = GetStringAsync();
+			var task3 = GetStringAsync();
+			var task4 = GetStringAsync();
+			var task5 = GetStringAsync();
+			var task6 = GetStringAsync();
+			var task7 = GetStringAsync();
+			var task8 = GetStringAsync();
+			var task9 = GetStringAsync();
+			var slowTask = GetIntSlowAsync();
+			var waitAllTask = (task1, task2, task3, task4, task5, task6, task7, task8, task9, slowTask)
+				.ConfigureAwait(continueOnCapturedContext);
+
+			waitAllTask.GetAwaiter().OnCompleted(() =>
+			{
+				Assert.True(task1.IsCompleted);
+				Assert.True(task2.IsCompleted);
+				Assert.True(task3.IsCompleted);
+				Assert.True(task4.IsCompleted);
+				Assert.True(task5.IsCompleted);
+				Assert.True(task6.IsCompleted);
+				Assert.True(task7.IsCompleted);
+				Assert.True(task8.IsCompleted);
+				Assert.True(task9.IsCompleted);
+				Assert.True(slowTask.IsCompleted);
+			});
+			var (a, b, c, d, e, f, g, h, i, k) = await waitAllTask;
+		}
+
 		private static async Task<string> GetStringAsync()
 		{
 			await Task.Delay(500);
@@ -139,6 +349,12 @@ namespace TaskTupleAwaiter.Tests
 		{
 			await Task.Delay(500);
 			return Guid.NewGuid();
+		}
+
+		private static async Task<int> GetIntSlowAsync()
+		{
+			await Task.Delay(1000);
+			return 42;
 		}
 	}
 }

--- a/src/TaskTupleAwaiter/TaskTupleExtensions.cs
+++ b/src/TaskTupleAwaiter/TaskTupleExtensions.cs
@@ -150,7 +150,7 @@ namespace TaskTupleAwaiter
 					bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -229,7 +229,7 @@ namespace TaskTupleAwaiter
 					bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -314,7 +314,7 @@ namespace TaskTupleAwaiter
 					bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -400,7 +400,8 @@ namespace TaskTupleAwaiter
 					bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3,
+						tasks.Item4, tasks.Item5, tasks.Item6)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -492,7 +493,8 @@ namespace TaskTupleAwaiter
 						tasks, bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3,
+						tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -586,7 +588,8 @@ namespace TaskTupleAwaiter
 						Task<T8>) tasks, bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3,
+						tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -681,7 +684,8 @@ namespace TaskTupleAwaiter
 						Task<T8>, Task<T9>) tasks, bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3,
+						tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -734,8 +738,8 @@ namespace TaskTupleAwaiter
 				_whenAllAwaiter.GetResult();
 				return (_tasks.Item1.Result, _tasks.Item2.Result, _tasks.Item3.Result,
 					_tasks.Item4.Result, _tasks.Item5.Result, _tasks.Item6.Result,
-					_tasks.Item7.Result, _tasks.Item8.Result, _tasks.Item9.Result, _tasks.Item10
-						.Result);
+					_tasks.Item7.Result, _tasks.Item8.Result, _tasks.Item9.Result,
+					_tasks.Item10.Result);
 			}
 		}
 
@@ -777,7 +781,9 @@ namespace TaskTupleAwaiter
 						Task<T8>, Task<T9>, Task<T10>) tasks, bool continueOnCapturedContext)
 				{
 					_tasks = tasks;
-					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
+					_whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3,
+						tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9,
+						tasks.Item10)
 						.ConfigureAwait(continueOnCapturedContext).GetAwaiter();
 				}
 
@@ -791,8 +797,8 @@ namespace TaskTupleAwaiter
 					_whenAllAwaiter.GetResult();
 					return (_tasks.Item1.Result, _tasks.Item2.Result, _tasks.Item3.Result,
 						_tasks.Item4.Result, _tasks.Item5.Result, _tasks.Item6.Result,
-						_tasks.Item7.Result, _tasks.Item8.Result, _tasks.Item9.Result, _tasks
-							.Item10.Result);
+						_tasks.Item7.Result, _tasks.Item8.Result, _tasks.Item9.Result,
+						_tasks.Item10.Result);
 				}
 			}
 		}


### PR DESCRIPTION
It looks like a copy/paste bug inside TupleConfiguredTaskAwaitable costructors. When creating a new task using **Task.WhenAll** only 2 tasks passed out of 3, 4, 5. etc.

```csharp
public Awaiter((Task<T1>, Task<T2>, Task<T3>) tasks, bool continueOnCapturedContext)
{
   _tasks = tasks;
   _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2)
      .ConfigureAwait(continueOnCapturedContext)
      .GetAwaiter();
}
```
Expected behavior is to wait for all tasks:

```csharp
public Awaiter((Task<T1>, Task<T2>, Task<T3>) tasks, bool continueOnCapturedContext)
{
   _tasks = tasks;
   _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3)
      .ConfigureAwait(continueOnCapturedContext)
      .GetAwaiter();
}
```