### PR TITLE
Fix failing tests and update tested runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET Core 5.0 Preview 7 SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.*
+        dotnet-version: 5.0.100-preview.7.20366.6
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET Core 5.0 Preview 7 SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.*
+        dotnet-version: 5.0.100-preview.7.20366.6
     - name: Create NuGet Package
       run: dotnet pack -c Release -o . /p:Version=${{ github.event.release.tag_name }} /p:PackageReleaseNotes="See https://github.com/buvinghausen/TaskTupleAwaiter/releases/tag/${{ github.event.release.tag_name }}"
     - name: Publish NuGet Package

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "5.0.100-preview.7",
+    "allowPrerelease": true,
+    "rollForward": "feature"
+  }
+}

--- a/src/TaskTupleAwaiter.Tests/BehaviorComparisonTests.cs
+++ b/src/TaskTupleAwaiter.Tests/BehaviorComparisonTests.cs
@@ -181,13 +181,11 @@ namespace TaskTupleAwaiter.Tests
 
 				source.SetResult(null);
 
-				for (var i = 0; i < adapters.Count; i++)
-				{
-					if (shouldUseSynchronizationContext)
-						Assert.Same(expected: copyableContext, actual: actualContinuationContextByAdapterIndex[i]);
-					else
-						Assert.Null(actualContinuationContextByAdapterIndex[i]);
-				}
+				var expected = shouldUseSynchronizationContext ? copyableContext : null;
+
+				Assert.All(
+					adapters.Zip(actualContinuationContextByAdapterIndex, (adapter, result) => (Adapter: adapter, Result: result)),
+					r => Assert.Same(expected, r.Result));
 			}
 		}
 

--- a/src/TaskTupleAwaiter.Tests/BehaviorComparisonTests.cs
+++ b/src/TaskTupleAwaiter.Tests/BehaviorComparisonTests.cs
@@ -145,24 +145,24 @@ namespace TaskTupleAwaiter.Tests
 		}
 
 		[Theory, MemberData(nameof(EachArity))]
-		public static void NonConfiguredAwaitUsesSynchronizationContext(int arity)
+		public static async Task NonConfiguredAwaitUsesSynchronizationContext(int arity)
 		{
-			AssertUsesSynchronizationContext(arity, configureAwait: null, shouldUseSynchronizationContext: true);
+			await AssertUsesSynchronizationContext(arity, configureAwait: null, shouldUseSynchronizationContext: true);
 		}
 
 		[Theory, MemberData(nameof(EachArity))]
-		public static void ConfigureAwaitTrueUsesSynchronizationContext(int arity)
+		public static async Task ConfigureAwaitTrueUsesSynchronizationContext(int arity)
 		{
-			AssertUsesSynchronizationContext(arity, configureAwait: true, shouldUseSynchronizationContext: true);
+			await AssertUsesSynchronizationContext(arity, configureAwait: true, shouldUseSynchronizationContext: true);
 		}
 
 		[Theory, MemberData(nameof(EachArity))]
-		public static void ConfigureAwaitFalseDoesNotUseSynchronizationContext(int arity)
+		public static async Task ConfigureAwaitFalseDoesNotUseSynchronizationContext(int arity)
 		{
-			AssertUsesSynchronizationContext(arity, configureAwait: false, shouldUseSynchronizationContext: false);
+			await AssertUsesSynchronizationContext(arity, configureAwait: false, shouldUseSynchronizationContext: false);
 		}
 
-		private static void AssertUsesSynchronizationContext(int arity, bool? configureAwait, bool shouldUseSynchronizationContext)
+		private static async Task AssertUsesSynchronizationContext(int arity, bool? configureAwait, bool shouldUseSynchronizationContext)
 		{
 			var source = new TaskCompletionSource<object>();
 
@@ -171,20 +171,22 @@ namespace TaskTupleAwaiter.Tests
 			var copyableContext = new CopyableSynchronizationContext();
 			using (TempSyncContext(copyableContext))
 			{
-				var actualContinuationContextByAdapterIndex = new SynchronizationContext[adapters.Count];
+				var resultSourcesByAdapterIndex = adapters.Select(_ => new TaskCompletionSource<SynchronizationContext>()).ToArray();
 
 				for (var i = 0; i < adapters.Count; i++)
 				{
 					var adapterIndex = i;
-					adapters[i].OnCompleted(() => actualContinuationContextByAdapterIndex[adapterIndex] = SynchronizationContext.Current);
+					adapters[i].OnCompleted(() => resultSourcesByAdapterIndex[adapterIndex].SetResult(SynchronizationContext.Current));
 				}
 
 				source.SetResult(null);
 
+				var resultsByAdapterIndex = await Task.WhenAll(resultSourcesByAdapterIndex.Select(s => s.Task));
+
 				var expected = shouldUseSynchronizationContext ? copyableContext : null;
 
 				Assert.All(
-					adapters.Zip(actualContinuationContextByAdapterIndex, (adapter, result) => (Adapter: adapter, Result: result)),
+					adapters.Zip(resultsByAdapterIndex, (adapter, result) => (Adapter: adapter, Result: result)),
 					r => Assert.Same(expected, r.Result));
 			}
 		}

--- a/src/TaskTupleAwaiter.Tests/CopyableSynchronizationContext.cs
+++ b/src/TaskTupleAwaiter.Tests/CopyableSynchronizationContext.cs
@@ -4,9 +4,8 @@ namespace TaskTupleAwaiter.Tests
 {
 	internal sealed class CopyableSynchronizationContext : SynchronizationContext
 	{
-		public override SynchronizationContext CreateCopy()
-		{
-			return new CopyableSynchronizationContext();
-		}
+		public override SynchronizationContext CreateCopy() => new CopyableSynchronizationContext();
+
+		public override void Post(SendOrPostCallback d, object state) => d.Invoke(state);
 	}
 }

--- a/src/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
+++ b/src/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
+++ b/src/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
@@ -1,29 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.1;netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <Choose>
-    <!--For .NET Core 2.0 and below which are unsupported you must use 16.2.0 of the test SDK -->
-    <When Condition="'$(TargetFramework)' == 'netcoreapp2.0' or '$(TargetFramework)' == 'netcoreapp1.1' or '$(TargetFramework)' == 'netcoreapp1.0'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order to open the solution, the last commit requires you to install .NET 5 preview 7 and either use a side-by-side preview of VS or set the option in non-preview VS to use preview SDKs.

@buvinghausen Could you set up an appveyor.yml file for the repo so that I can have it install the preview SDK? I can't access https://ci.appveyor.com/project/buvinghausen/tasktupleawaiter/settings. Or is AppVeyor now redundant?