### PR TITLE
Replace <PackageLicenseFile> with <PackageLicenseExpression>

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>Joseph Musser,Brian Buvinghausen</Authors>
     <Company>Buvinghausen Solutions</Company>
     <Copyright>Copyright © 2025 Brian Buvinghausen</Copyright>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/buvinghausen/TaskTupleAwaiter/blob/master/README.md</PackageProjectUrl>
     <PackageTags>C# 7.0;Value Tuple;Async Await Elegant Code</PackageTags>


### PR DESCRIPTION
Because an embedded license file is used instead of an SPDX tag, automated tools like [nuget-license](https://github.com/tomchavakis/nuget-license) and [packageguard](https://github.com/dennisdoomen/packageguard) are unable to detect this package's license. Also the license does not show up in the package's metadata in nuget.

[Packing a license expression or a license file
](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file) recommends that MIT-licensed packages should have `<PackageLicenseExpression>MIT</PackageLicenseExpression>` instead of referring to a file.

The `License.md` file can still remain in the package, just the metadata would change.