### PR TITLE
Work around incompatibility with System.ValueTuple 4.6.1 and add .NET 10 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
+        dotnet-version: |
           8.0.*
           9.0.*
+          10.0.*
       env:
         DOTNET_NOLOGO: 1
         DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.*
+        dotnet-version: 10.0.*
       env:
         DOTNET_NOLOGO: 1
         DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <Authors>Joseph Musser,Brian Buvinghausen</Authors>
     <Company>Buvinghausen Solutions</Company>
     <Copyright>Copyright © 2025 Brian Buvinghausen</Copyright>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <Authors>Joseph Musser,Brian Buvinghausen</Authors>
     <Company>Buvinghausen Solutions</Company>
     <Copyright>Copyright © 2025 Brian Buvinghausen</Copyright>

--- a/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
+++ b/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Title>TaskTupleAwaiter</Title>
@@ -14,8 +14,4 @@ Based on the work of Joseph Musser https://github.com/jnm2
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
-  </ItemGroup>
-  
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <MSBuildTreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</MSBuildTreatWarningsAsErrors>
     <ImplicitUsings>true</ImplicitUsings>


### PR DESCRIPTION
Fixes #34. This workaround is one of the three options identified at https://github.com/buvinghausen/TaskTupleAwaiter/issues/34#issuecomment-3519340657. I prefer this approach because it targets the minimum API set that the package needs. Adding an additional newer target, while keeping the older one, is only useful if it's consuming an API that's not available in the older target. (Like we do with .NET 8 and its ConfigureAwaitOptions.)