### PR TITLE
Add valuetask

### DIFF
--- a/src/TaskTupleAwaiter.Generator/TaskTupleAwaiter.Generator.csproj
+++ b/src/TaskTupleAwaiter.Generator/TaskTupleAwaiter.Generator.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/TaskTupleAwaiter.Generator/TaskTupleExtensionsGenerator.cs
+++ b/src/TaskTupleAwaiter.Generator/TaskTupleExtensionsGenerator.cs
@@ -48,6 +48,13 @@ public sealed class TaskTupleExtensionsGenerator : IIncrementalGenerator
 
 		AppendNonGenericSection(sb, isNet8OrGreater);
 
+		AppendValueTaskTypedArity1(sb);
+		for (var arity = 2; arity <= MaxArity; arity++)
+			AppendValueTaskTypedArity(sb, arity, isNet8OrGreater);
+
+		if (isNet8OrGreater)
+			AppendNonGenericValueTaskSection(sb);
+
 		sb.AppendLine("}");
 		return sb.ToString();
 	}
@@ -261,6 +268,99 @@ public sealed class TaskTupleExtensionsGenerator : IIncrementalGenerator
 		sb.AppendLine($"\t\tTask.WhenAll({Items(arity)}).ConfigureAwait(options);");
 	}
 
+	// ── Typed ValueTask<T> ───────────────────────────────────────────────
+
+	private static void AppendValueTaskTypedArity1(StringBuilder sb)
+	{
+		sb.AppendLine("	#region (ValueTask<T1>)");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine("	public static ValueTaskAwaiter<T1> GetAwaiter<T1>(this ValueTuple<ValueTask<T1>> tasks) =>");
+		sb.AppendLine("		tasks.Item1.GetAwaiter();");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine("	public static ConfiguredValueTaskAwaitable<T1> ConfigureAwait<T1>(this ValueTuple<ValueTask<T1>> tasks, bool continueOnCapturedContext) =>");
+		sb.AppendLine("		tasks.Item1.ConfigureAwait(continueOnCapturedContext);");
+
+		sb.AppendLine();
+		sb.AppendLine("	#endregion");
+		sb.AppendLine();
+	}
+
+	private static void AppendValueTaskTypedArity(StringBuilder sb, int arity, bool isNet8OrGreater)
+	{
+		var tp = TypeParams(arity);
+		var valueTaskTupleType = ValueTaskTypedTupleType(arity);
+		var asTaskArgs = AsTaskItems(arity);
+		var configureAwaitBoolArg = isNet8OrGreater
+			? "continueOnCapturedContext ? ConfigureAwaitOptions.ContinueOnCapturedContext : ConfigureAwaitOptions.None"
+			: "continueOnCapturedContext";
+
+		sb.AppendLine($"	#region (ValueTask<T1>..ValueTask<T{arity}>)");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine($"	public static TupleTaskAwaiter<{tp}> GetAwaiter<{tp}>(this {valueTaskTupleType} tasks) =>");
+		sb.AppendLine($"		new(({asTaskArgs}));");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine($"	public static TupleConfiguredTaskAwaitable<{tp}> ConfigureAwait<{tp}>(this {valueTaskTupleType} tasks, bool continueOnCapturedContext) =>");
+		sb.AppendLine($"		new(({asTaskArgs}), {configureAwaitBoolArg});");
+
+		if (isNet8OrGreater)
+		{
+			sb.AppendLine();
+			sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+			sb.AppendLine($"	public static TupleConfiguredTaskAwaitable<{tp}> ConfigureAwait<{tp}>(this {valueTaskTupleType} tasks, ConfigureAwaitOptions options) =>");
+			sb.AppendLine($"		new(({asTaskArgs}), options);");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("	#endregion");
+		sb.AppendLine();
+	}
+
+	// ── Non-generic ValueTask (NET8+ only) ────────────────────────────────
+
+	private static void AppendNonGenericValueTaskSection(StringBuilder sb)
+	{
+		sb.AppendLine("	#region ValueTask");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine("	public static ValueTaskAwaiter GetAwaiter(this ValueTuple<ValueTask> tasks) =>");
+		sb.AppendLine("		tasks.Item1.GetAwaiter();");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine("	public static ConfiguredValueTaskAwaitable ConfigureAwait(this ValueTuple<ValueTask> tasks, bool continueOnCapturedContext) =>");
+		sb.AppendLine("		tasks.Item1.ConfigureAwait(continueOnCapturedContext);");
+
+		for (var arity = 2; arity <= MaxArity; arity++)
+		{
+			sb.AppendLine();
+			AppendNonGenericValueTaskArity(sb, arity);
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("	#endregion");
+	}
+
+	private static void AppendNonGenericValueTaskArity(StringBuilder sb, int arity)
+	{
+		var tupleType = NonGenericValueTaskTupleType(arity);
+		var asTaskArgs = AsTaskItems(arity);
+
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine($"	public static TaskAwaiter GetAwaiter(this {tupleType} tasks) =>");
+		sb.AppendLine($"		Task.WhenAll({asTaskArgs}).GetAwaiter();");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine($"	public static ConfiguredTaskAwaitable ConfigureAwait(this {tupleType} tasks, bool continueOnCapturedContext) =>");
+		sb.AppendLine($"		Task.WhenAll({asTaskArgs}).ConfigureAwait(continueOnCapturedContext);");
+		sb.AppendLine();
+		sb.AppendLine("	/// <summary>This type and its members are intended for use by the compiler.</summary>");
+		sb.AppendLine($"	public static ConfiguredTaskAwaitable ConfigureAwait(this {tupleType} tasks, ConfigureAwaitOptions options) =>");
+		sb.AppendLine($"		Task.WhenAll({asTaskArgs}).ConfigureAwait(options);");
+	}
+
 	// ── String helpers ────────────────────────────────────────────────────
 
 	private static string TypeParams(int arity) =>
@@ -277,4 +377,13 @@ public sealed class TaskTupleExtensionsGenerator : IIncrementalGenerator
 
 	private static string Results(int arity) =>
 		string.Join(", ", Enumerable.Range(1, arity).Select(i => $"_tasks.Item{i}.Result"));
+
+	private static string ValueTaskTypedTupleType(int arity) =>
+		"(" + string.Join(", ", Enumerable.Range(1, arity).Select(i => $"ValueTask<T{i}>")) + ")";
+
+	private static string AsTaskItems(int arity) =>
+		string.Join(", ", Enumerable.Range(1, arity).Select(i => $"tasks.Item{i}.AsTask()"));
+
+	private static string NonGenericValueTaskTupleType(int arity) =>
+		"(" + string.Join(", ", Enumerable.Repeat("ValueTask", arity)) + ")";
 }

--- a/src/TaskTupleAwaiter.Generator/TaskTupleExtensionsGenerator.cs
+++ b/src/TaskTupleAwaiter.Generator/TaskTupleExtensionsGenerator.cs
@@ -9,15 +9,34 @@ public sealed class TaskTupleExtensionsGenerator : IIncrementalGenerator
 {
 	private const int MaxArity = 16;
 
-	public void Initialize(IncrementalGeneratorInitializationContext context) =>
-		context.RegisterSourceOutput(
-			context.ParseOptionsProvider,
-			static (ctx, parseOptions) =>
+	public void Initialize(IncrementalGeneratorInitializationContext context)
+	{
+		// Skip code generation when TaskTupleExtensions already exists in a different assembly.
+		// This allows the generator assembly to be loaded as an analyzer-only in consumer projects
+		// (for the DiagnosticSuppressor) without re-generating types already compiled into the library.
+		// The assembly identity check works in both MSBuild (metadata references) and the VS IDE
+		// (project-to-project compilation references).
+		var shouldGenerate = context.CompilationProvider
+			.Select(static (compilation, _) =>
 			{
+				var existing = compilation.GetTypeByMetadataName("System.Threading.Tasks.TaskTupleExtensions");
+				return existing is null
+					   || SymbolEqualityComparer.Default.Equals(existing.ContainingAssembly, compilation.Assembly);
+			});
+
+		context.RegisterSourceOutput(
+			shouldGenerate.Combine(context.ParseOptionsProvider),
+			static (ctx, source) =>
+			{
+				var (generate, parseOptions) = source;
+				if (!generate)
+					return;
+
 				var isNet8OrGreater = parseOptions is CSharpParseOptions csOptions &&
 									  csOptions.PreprocessorSymbolNames.Contains("NET8_0_OR_GREATER");
 				ctx.AddSource("TaskTupleExtensions.g.cs", GenerateSource(isNet8OrGreater));
 			});
+	}
 
 	private static string GenerateSource(bool isNet8OrGreater)
 	{

--- a/src/TaskTupleAwaiter.Generator/ValueTaskTupleSuppressor.cs
+++ b/src/TaskTupleAwaiter.Generator/ValueTaskTupleSuppressor.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TaskTupleAwaiter.Generator;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ValueTaskTupleSuppressor : DiagnosticSuppressor
+{
+	internal static readonly SuppressionDescriptor Rule = new(
+		id: "TTA0001",
+		suppressedDiagnosticId: "CA2012",
+		justification:
+		"ValueTask<T> used as an element of a tuple awaited via TaskTupleAwaiter is safely consumed via .AsTask().");
+
+	public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
+		[Rule];
+
+	public override void ReportSuppressions(SuppressionAnalysisContext context)
+	{
+		foreach (var diagnostic in context.ReportedDiagnostics
+			         .Select(diagnostic => new { diagnostic, tree = diagnostic.Location.SourceTree })
+			         .Where(@t => @t.tree is not null)
+			         .Select(@t => new { @t, root = @t.tree.GetRoot(context.CancellationToken) })
+			         .Select(@t => new
+			         {
+				         @t,
+				         node = @t.root.FindNode(@t.@t.diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+			         })
+			         .Where(@t => IsInsideAwaitedTuple(@t.node))
+			         .Select(@t => @t.@t.@t.diagnostic))
+		{
+			context.ReportSuppression(Suppression.Create(Rule, diagnostic));
+		}
+	}
+
+	private static bool IsInsideAwaitedTuple(SyntaxNode node)
+	{
+		var current = node;
+		while (current is not null)
+		{
+			if (current is TupleExpressionSyntax tupleExpr)
+				return IsAwaited(tupleExpr);
+
+			// Don't walk past statement boundaries
+			if (current is StatementSyntax)
+				break;
+
+			current = current.Parent;
+		}
+
+		return false;
+	}
+
+	private static bool IsAwaited(SyntaxNode node)
+	{
+		var parent = node.Parent;
+		// Direct: await (vt1, vt2)
+		return parent is AwaitExpressionSyntax ||
+			   // Via ConfigureAwait: await (vt1, vt2).ConfigureAwait(...)
+			   parent is MemberAccessExpressionSyntax
+			   {
+				   Name.Identifier.Text: "ConfigureAwait", Parent: InvocationExpressionSyntax
+				   {
+					   Parent: AwaitExpressionSyntax
+				   }
+			   };
+	}
+}

--- a/src/TaskTupleAwaiter.Generator/ValueTaskTupleSuppressor.cs
+++ b/src/TaskTupleAwaiter.Generator/ValueTaskTupleSuppressor.cs
@@ -19,19 +19,22 @@ public sealed class ValueTaskTupleSuppressor : DiagnosticSuppressor
 
 	public override void ReportSuppressions(SuppressionAnalysisContext context)
 	{
-		foreach (var diagnostic in context.ReportedDiagnostics
-			         .Select(diagnostic => new { diagnostic, tree = diagnostic.Location.SourceTree })
-			         .Where(@t => @t.tree is not null)
-			         .Select(@t => new { @t, root = @t.tree.GetRoot(context.CancellationToken) })
-			         .Select(@t => new
-			         {
-				         @t,
-				         node = @t.root.FindNode(@t.@t.diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
-			         })
-			         .Where(@t => IsInsideAwaitedTuple(@t.node))
-			         .Select(@t => @t.@t.@t.diagnostic))
+		var rootCache = new Dictionary<SyntaxTree, SyntaxNode>();
+		foreach (var diagnostic in context.ReportedDiagnostics)
 		{
-			context.ReportSuppression(Suppression.Create(Rule, diagnostic));
+			var tree = diagnostic.Location.SourceTree;
+			if (tree is null)
+				continue;
+
+			if (!rootCache.TryGetValue(tree, out var root))
+			{
+				root = tree.GetRoot(context.CancellationToken);
+				rootCache[tree] = root;
+			}
+
+			var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+			if (IsInsideAwaitedTuple(node))
+				context.ReportSuppression(Suppression.Create(Rule, diagnostic));
 		}
 	}
 
@@ -55,16 +58,24 @@ public sealed class ValueTaskTupleSuppressor : DiagnosticSuppressor
 
 	private static bool IsAwaited(SyntaxNode node)
 	{
-		var parent = node.Parent;
+		// Skip over any extra parentheses around the tuple expression
+		var current = node.Parent;
+		while (current is ParenthesizedExpressionSyntax)
+		{
+			current = current.Parent;
+		}
+
 		// Direct: await (vt1, vt2)
-		return parent is AwaitExpressionSyntax ||
-			   // Via ConfigureAwait: await (vt1, vt2).ConfigureAwait(...)
-			   parent is MemberAccessExpressionSyntax
-			   {
-				   Name.Identifier.Text: "ConfigureAwait", Parent: InvocationExpressionSyntax
-				   {
-					   Parent: AwaitExpressionSyntax
-				   }
-			   };
+		if (current is AwaitExpressionSyntax)
+			return true;
+
+		// Via ConfigureAwait: await (vt1, vt2).ConfigureAwait(...)
+		return current is MemberAccessExpressionSyntax
+		{
+			Name.Identifier.Text: "ConfigureAwait", Parent: InvocationExpressionSyntax
+			{
+				Parent: AwaitExpressionSyntax
+			}
+		};
 	}
 }

--- a/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
+++ b/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
@@ -26,4 +26,16 @@ Based on the work of Joseph Musser https://github.com/jnm2
     <ProjectReference Include="..\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <!-- Include the generator/suppressor assembly in the NuGet package so consumers
+       automatically get the DiagnosticSuppressor for CA2012. -->
+  <Target Name="_IncludeAnalyzerInPackage" BeforeTargets="_GetPackageFiles" DependsOnTargets="ResolveProjectReferences">
+    <MSBuild Projects="..\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj"
+             Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_GeneratorAssembly" />
+    </MSBuild>
+    <ItemGroup>
+      <None Include="@(_GeneratorAssembly)" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
+++ b/src/TaskTupleAwaiter/TaskTupleAwaiter.csproj
@@ -18,6 +18,10 @@ Based on the work of Joseph Musser https://github.com/jnm2
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -21,4 +21,8 @@
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.*" />
+  </ItemGroup>
+
 </Project>

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj
@@ -5,5 +5,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\TaskTupleAwaiter\TaskTupleAwaiter.csproj" />
+    <ProjectReference Include="..\..\src\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -579,14 +579,6 @@ public sealed class TaskTupleAwaiterTests
 	}
 
 	[Fact]
-	async Task CanAwaitTwoValueTasksWithNewSyntaxAndConfigureAwaitFalse()
-	{
-		var (a, b) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync()).ConfigureAwait(false);
-		a.ShouldBeOfType<string>();
-		b.ShouldBeOfType<Guid>();
-	}
-
-	[Fact]
 	async Task CanAwaitThreeValueTasksWithNewSyntax()
 	{
 		var (a, b, c) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -1,3 +1,8 @@
+// CA2012 is intentionally suppressed here: these tests exist specifically to prove that
+// ValueTask<T> instances can be safely placed in a tuple and awaited via TaskTupleAwaiter.
+// The library calls .AsTask() on construction, satisfying the single-consumption requirement.
+#pragma warning disable CA2012
+
 namespace TaskTupleAwaiter.Tests;
 
 public sealed class TaskTupleAwaiterTests
@@ -562,6 +567,251 @@ public sealed class TaskTupleAwaiterTests
 		(task1.IsCompleted & task2.IsCompleted & task3.IsCompleted & task4.IsCompleted & task5.IsCompleted & task6.IsCompleted & task7.IsCompleted & task8.IsCompleted & task9.IsCompleted & task10.IsCompleted & task11.IsCompleted & task12.IsCompleted & task13.IsCompleted & task14.IsCompleted & task15.IsCompleted).ShouldBeTrue();
 	}
 
+	[Fact]
+	async Task CanAwaitTwoValueTasksWithNewSyntax()
+	{
+		var (a, b) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitThreeValueTasksWithNewSyntax()
+	{
+		var (a, b, c) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitFourValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitFiveValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitSixValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitSevenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitEightValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitNineValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitTenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitElevenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitTwelveValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k, l) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+		l.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitThirteenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k, l, m) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+		l.ShouldBeOfType<Guid>();
+		m.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitFourteenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k, l, m, n) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+		l.ShouldBeOfType<Guid>();
+		m.ShouldBeOfType<string>();
+		n.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
+	async Task CanAwaitFifteenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+		l.ShouldBeOfType<Guid>();
+		m.ShouldBeOfType<string>();
+		n.ShouldBeOfType<Guid>();
+		o.ShouldBeOfType<string>();
+	}
+
+	[Fact]
+	async Task CanAwaitSixteenValueTasksWithNewSyntax()
+	{
+		var (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync(), GetGuidValueTaskAsync());
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+		c.ShouldBeOfType<string>();
+		d.ShouldBeOfType<Guid>();
+		e.ShouldBeOfType<string>();
+		f.ShouldBeOfType<Guid>();
+		g.ShouldBeOfType<string>();
+		h.ShouldBeOfType<Guid>();
+		i.ShouldBeOfType<string>();
+		j.ShouldBeOfType<Guid>();
+		k.ShouldBeOfType<string>();
+		l.ShouldBeOfType<Guid>();
+		m.ShouldBeOfType<string>();
+		n.ShouldBeOfType<Guid>();
+		o.ShouldBeOfType<string>();
+		p.ShouldBeOfType<Guid>();
+	}
+
+	[Theory]
+	[MemberData(nameof(ContinueOnCapturedContextOptions))]
+	async Task AwaitTwoValueTasksWaitsForBothWhenConfigured(bool continueOnCapturedContext)
+	{
+		var valueTask1 = GetStringValueTaskAsync();
+		var valueTask2 = GetGuidValueTaskAsync();
+
+		var (a, b) = await (valueTask1, valueTask2).ConfigureAwait(continueOnCapturedContext);
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+	}
+
+#if NET8_0_OR_GREATER
+	[Fact]
+	async Task CanAwaitTwoNonGenericValueTasksWithNewSyntax() => await (GetVoidValueTaskAsync(), GetVoidValueTaskAsync());
+
+	[Fact]
+	async Task CanAwaitThreeNonGenericValueTasksWithNewSyntax() => await (GetVoidValueTaskAsync(), GetVoidValueTaskAsync(), GetVoidValueTaskAsync());
+#endif
+
 	static async Task<string> GetStringAsync()
 	{
 		await Task.Yield();
@@ -573,4 +823,12 @@ public sealed class TaskTupleAwaiterTests
 		await Task.Yield();
 		return Guid.NewGuid();
 	}
+
+	static ValueTask<string> GetStringValueTaskAsync() => new(GetStringAsync());
+
+	static ValueTask<Guid> GetGuidValueTaskAsync() => new(GetGuidAsync());
+
+#if NET8_0_OR_GREATER
+	static async ValueTask GetVoidValueTaskAsync() => await Task.Yield();
+#endif
 }

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -1,8 +1,3 @@
-// CA2012 is intentionally suppressed here: these tests exist specifically to prove that
-// ValueTask<T> instances can be safely placed in a tuple and awaited via TaskTupleAwaiter.
-// The library calls .AsTask() on construction, satisfying the single-consumption requirement.
-#pragma warning disable CA2012
-
 namespace TaskTupleAwaiter.Tests;
 
 public sealed class TaskTupleAwaiterTests

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -579,6 +579,14 @@ public sealed class TaskTupleAwaiterTests
 	}
 
 	[Fact]
+	async Task CanAwaitTwoValueTasksWithNewSyntaxAndConfigureAwaitFalse()
+	{
+		var (a, b) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync()).ConfigureAwait(false);
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
 	async Task CanAwaitThreeValueTasksWithNewSyntax()
 	{
 		var (a, b, c) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());

--- a/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
+++ b/test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs
@@ -571,6 +571,14 @@ public sealed class TaskTupleAwaiterTests
 	}
 
 	[Fact]
+	async Task CanAwaitTwoValueTasksWithNewSyntaxAndConfigureAwaitFalse()
+	{
+		var (a, b) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync()).ConfigureAwait(false);
+		a.ShouldBeOfType<string>();
+		b.ShouldBeOfType<Guid>();
+	}
+
+	[Fact]
 	async Task CanAwaitThreeValueTasksWithNewSyntax()
 	{
 		var (a, b, c) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync(), GetStringValueTaskAsync());


### PR DESCRIPTION
## Suppress CA2012 for `ValueTask<T>` tuple-await pattern

### Problem

CA2012 ("Use ValueTasks correctly") fires whenever a method returning `ValueTask<T>` is called and the result is placed into a tuple rather than directly awaited:

```csharp
// CA2012 fires on both invocations — the analyzer can't see that the library
// consumes each ValueTask safely via .AsTask() inside the GetAwaiter extension.
var (a, b) = await (GetStringValueTaskAsync(), GetGuidValueTaskAsync());
```

This is a false positive for this library's intended usage. With `TreatWarningsAsErrors` enabled it becomes a hard build error, forcing users to scatter `#pragma warning disable CA2012` throughout their code.

---

### Solution

Ship a `DiagnosticSuppressor` in the existing generator assembly that automatically suppresses CA2012 at the right call sites. Three issues had to be solved to make that work end-to-end.

---

### Changes

#### `src/TaskTupleAwaiter.Generator/ValueTaskTupleSuppressor.cs` *(new)*

A `DiagnosticSuppressor` (suppression ID `TTA0001`) that suppresses CA2012 when the flagged `ValueTask<T>` invocation is an element of a tuple expression that is directly awaited or awaited via `.ConfigureAwait(...)`. Pure syntax-tree walk, no semantic model required.

Handles both patterns users write:

```csharp
await (GetValueTaskAsync(), ...)                       // direct await
await (GetValueTaskAsync(), ...).ConfigureAwait(false) // configured await
```

#### `src/TaskTupleAwaiter.Generator/TaskTupleExtensionsGenerator.cs`

Updated `Initialize` to guard against code generation when `TaskTupleExtensions` already exists in a **different** assembly from the one currently being compiled:

```csharp
var existing = compilation.GetTypeByMetadataName("System.Threading.Tasks.TaskTupleExtensions");
return existing is null
       || SymbolEqualityComparer.Default.Equals(existing.ContainingAssembly, compilation.Assembly);
```

This is necessary because the generator assembly now needs to be loadable as an **analyzer-only** reference in consumer projects (to deliver the suppressor) without re-generating types that are already compiled into `TaskTupleAwaiter.dll`. The assembly identity check — rather than an `IsInMetadata` location check — is used because Visual Studio uses project-to-project `CompilationReference` rather than metadata references, which would make the location-based check incorrect in the IDE.

Behaviour by scenario:

| Scenario | Result |
|---|---|
| Building `TaskTupleAwaiter` itself | `existing` is `null` → **generates** ✅ |
| Incremental rebuild of `TaskTupleAwaiter` | `existing.ContainingAssembly == compilation.Assembly` → **generates** ✅ |
| Consumer project (MSBuild metadata ref) | `existing` is from a different assembly → **skips** ✅ |
| Consumer project (VS IDE compilation ref) | `existing` is from a different assembly → **skips** ✅ |

#### `src/TaskTupleAwaiter/TaskTupleAwaiter.csproj`

Added an MSBuild target that packs the generator DLL into `analyzers\dotnet\cs\` in the NuGet package. This is the standard mechanism by which analyzer/suppressor assemblies are automatically loaded in any project that installs the package — no manual configuration required from consumers.

```xml
<Target Name="_IncludeAnalyzerInPackage" BeforeTargets="_GetPackageFiles" DependsOnTargets="ResolveProjectReferences">
  <MSBuild Projects="..\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj"
           Targets="GetTargetPath">
    <Output TaskParameter="TargetOutputs" ItemName="_GeneratorAssembly" />
  </MSBuild>
  <ItemGroup>
    <None Include="@(_GeneratorAssembly)" Pack="true" PackagePath="analyzers\dotnet\cs" Visible="false" />
  </ItemGroup>
</Target>
```

#### `test/TaskTupleAwaiter.Tests/TaskTupleAwaiter.Tests.csproj`

Added the generator as a second project reference with `OutputItemType="Analyzer"`. Because the generator now skips code generation for consumers, this adds only the suppressor to the test build — no duplicate type definitions.

```xml
<ProjectReference Include="..\..\src\TaskTupleAwaiter.Generator\TaskTupleAwaiter.Generator.csproj"
                  OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
```

#### `test/TaskTupleAwaiter.Tests/TaskTupleAwaiterTests.cs`

Removed the file-wide `#pragma warning disable CA2012`